### PR TITLE
Fix “Sample Characters” URLs

### DIFF
--- a/Characters/Sample-Characters/README.md
+++ b/Characters/Sample-Characters/README.md
@@ -3,16 +3,16 @@
 This section contains the info for nine different sample characters to serve as quickstart characters for your campaign, or to serve as inspiration for creating your own.
 
 ## Tier 1 Characters
-* [Malachi](../Characters/Sample-Characters/Malachi)
-* [Gemini](../Characters/Sample-Characters/Gemini)
-* [Mariana](../Characters/Sample-Characters/Mariana)
+* [Malachi](Malachi)
+* [Gemini](Gemini)
+* [Mariana](Mariana)
 
 ## Tier 5 Characters
-* [Jianna](../Characters/Sample-Characters/Jianna)
-* [Shae](../Characters/Sample-Characters/Shae)
-* [Emgol](../Characters/Sample-Characters/Emgol)
+* [Jianna](Jianna)
+* [Shae](Shae)
+* [Emgol](Emgol)
 
 ## Tier 10 Characters
-* [Isabella](../Characters/Sample-Characters/Isabella)
-* [Feerk](../Characters/Sample-Characters/Feerk)
-* [Azkhan](../Characters/Sample-Characters/Azkhan)
+* [Isabella](Isabella)
+* [Feerk](Feerk)
+* [Azkhan](Azkhan)


### PR DESCRIPTION
The relative URIs had taken the form `../Characters/Sample-Characters/Gemini`. In light of the base URI to which they’re relative, they pointed to resources that dunt exist, one with two `/Characters` path segments.

In case it ain’t already obvious to ya why that would be the case, it may be helpful to see the way path segments of `http` and `https` scheme URIs, as well as those with many other schemes, are interpreted as a series of instructions that can be thought of as moving a cursor “up” or “down” within a hierachical structure.

| # | PATH SEGMENT         | INSTRUCTION                 | PATH                                              |
|--:|----------------------|-----------------------------|---------------------------------------------------|
|   |                      | _(initial state; base URI)_ | `/Characters/Sample-Characters`                   |
| 0 | `..`                 | “go up one segment”         | `/Characters`                                     |
| 1 | `/Characters`        | “go down one, to...”        | `/Characters/Characters`                          |
| 2 | `/Sample-Characters` | “go down one, to...”        | `/Characters/Characters/Sample-Characters`        |
| 3 | `/Gemini`            | “go down one, to...”        | `/Characters/Characters/Sample-Characters/Gemini` |

As the real target is supposed to be `/Characters/Sample-Characters/Gemini` in this example, the most direct relative URI is just `Gemini` alone. One could also spell that `./Gemini`, which means the same thing. One could also use an absolute pathname (`/Characters/Sample-Characters/Gemini`) so that only the authority portion of the URI is relative, but unless Github rewrites the links in the repo’s own markdown views (not sure — but it would surprise me a bit if they did), such URIs would only lead to the expected behavior on the Github Pages site, not in the repo views.